### PR TITLE
Tests: convert tests to JUnit 5

### DIFF
--- a/echosvg-test/build.gradle
+++ b/echosvg-test/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	testImplementation project(':echosvg-test-swing')
 	testImplementation project(':echosvg-extension')
 	testImplementation project(':echosvg-svgrasterizer')
-	testImplementation "junit:junit:${junitVersion}"
+	testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
 	testImplementation "org.mozilla:rhino:${rhinoVersion}"
 	testImplementation "nu.validator:htmlparser:${htmlParserVersion}"
 	if (!project.getPluginManager().hasPlugin('eclipse')) {
@@ -56,6 +56,8 @@ publishing.publications.maven(MavenPublication).pom {
 }
 
 test {
+	useJUnitPlatform()
+
 	exclude 'io/sf/carte/echosvg/apps/rasterizer/MainTest.class'
 	exclude 'io/sf/carte/echosvg/bridge/*LoadTest.class'
 	exclude 'io/sf/carte/echosvg/bridge/*PermissionsTest.class'

--- a/echosvg-test/src/itest/java/io/sf/carte/echosvg/itest/InteractiveScriptingTest.java
+++ b/echosvg-test/src/itest/java/io/sf/carte/echosvg/itest/InteractiveScriptingTest.java
@@ -20,9 +20,9 @@ package io.sf.carte.echosvg.itest;
 
 import java.io.IOException;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.test.svg.JSVGRenderingAccuracyTest;
@@ -33,7 +33,7 @@ import io.sf.carte.echosvg.transcoder.TranscoderException;
  */
 public class InteractiveScriptingTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 		TestFonts.loadTestFonts();
 	}
@@ -79,7 +79,7 @@ public class InteractiveScriptingTest {
 	}
 
 	// Ignored by Batik
-	@Ignore
+	@Disabled
 	@Test
 	public void testRemoveLast() throws TranscoderException, IOException {
 		testDynamicUpdate("samples/tests/spec/scripting/removeLast.svg");

--- a/echosvg-test/src/itest/java/io/sf/carte/echosvg/itest/InteractiveTest.java
+++ b/echosvg-test/src/itest/java/io/sf/carte/echosvg/itest/InteractiveTest.java
@@ -20,8 +20,8 @@ package io.sf.carte.echosvg.itest;
 
 import java.io.IOException;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.test.svg.JSVGRenderingAccuracyTest;
@@ -32,7 +32,7 @@ import io.sf.carte.echosvg.transcoder.TranscoderException;
  */
 public class InteractiveTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 		TestFonts.loadTestFonts();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/anim/dom/NormalizedPathSegListTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/anim/dom/NormalizedPathSegListTest.java
@@ -18,16 +18,16 @@
  */
 package io.sf.carte.echosvg.anim.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
 import java.text.NumberFormat;
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGDocument;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/apps/rasterizer/MainTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/apps/rasterizer/MainTest.java
@@ -18,12 +18,12 @@
  */
 package io.sf.carte.echosvg.apps.rasterizer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.Color;
 import java.awt.geom.Rectangle2D;
@@ -36,7 +36,8 @@ import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestLocations;
 
@@ -50,7 +51,7 @@ import io.sf.carte.echosvg.test.TestLocations;
 @SuppressWarnings({ "deprecation", "removal" })
 public class MainTest {
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
@@ -68,7 +69,7 @@ public class MainTest {
 
 	// This test interferes with Gradle
 	// Run it from IDE only
-	@org.junit.Test
+	@Test
 	public void testMain() {
 		URL url;
 		try {
@@ -84,7 +85,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				File dst = c.getDst();
 				assertNotNull(dst);
-				assertEquals("-d", "samples", dst.getName());
+				assertEquals("samples", dst.getName(), "-d");
 			}
 
 			@Override
@@ -105,7 +106,7 @@ public class MainTest {
 				List<String> sources = c.getSources();
 				assertEquals(1, sources.size());
 				String src = sources.get(0);
-				assertEquals(ERROR_UNEXPECTED_SOURCES, rootDir + "samples/anne.svg", src);
+				assertEquals(rootDir + "samples/anne.svg", src, ERROR_UNEXPECTED_SOURCES);
 			}
 
 		};
@@ -121,7 +122,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				DestinationType type = c.getDestinationType();
 				assertEquals(DestinationType.JPEG, type);
-				assertEquals("-m", DestinationType.JPEG.toString(), type.toString());
+				assertEquals(DestinationType.JPEG.toString(), type.toString(), "-m");
 			}
 
 		};
@@ -134,7 +135,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				DestinationType type = c.getDestinationType();
 				assertEquals(DestinationType.JPEG, type);
-				assertEquals("-m", DestinationType.JPEG.toString(), type.toString());
+				assertEquals(DestinationType.JPEG.toString(), type.toString(), "-m");
 			}
 
 		};
@@ -147,7 +148,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				DestinationType type = c.getDestinationType();
 				assertEquals(DestinationType.JPEG, type);
-				assertEquals("-m", DestinationType.JPEG.toString(), type.toString());
+				assertEquals(DestinationType.JPEG.toString(), type.toString(), "-m");
 			}
 
 		};
@@ -160,7 +161,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				DestinationType type = c.getDestinationType();
 				assertEquals(DestinationType.PNG, type);
-				assertEquals("-m", DestinationType.PNG.toString(), type.toString());
+				assertEquals(DestinationType.PNG.toString(), type.toString(), "-m");
 			}
 
 		};
@@ -173,7 +174,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				DestinationType type = c.getDestinationType();
 				assertEquals(DestinationType.TIFF, type);
-				assertEquals("-m", DestinationType.TIFF.toString(), type.toString());
+				assertEquals(DestinationType.TIFF.toString(), type.toString(), "-m");
 			}
 
 		};
@@ -185,7 +186,7 @@ public class MainTest {
 			@Override
 			public void validate(SVGConverter c) {
 				float width = c.getWidth();
-				assertEquals("-w", 467.69f, width, 1e-3);
+				assertEquals(467.69f, width, 1e-3, "-w");
 			}
 
 		};
@@ -197,7 +198,7 @@ public class MainTest {
 			@Override
 			public void validate(SVGConverter c) {
 				float height = c.getHeight();
-				assertEquals("-h", 345.67, height, 1e-3);
+				assertEquals(345.67, height, 1e-3, "-h");
 			}
 
 		};
@@ -208,7 +209,7 @@ public class MainTest {
 			@Override
 			public void validate(SVGConverter c) {
 				float maxWidth = c.getMaxWidth();
-				assertEquals("-maxw", 467.69f, maxWidth, 1e-3);
+				assertEquals(467.69f, maxWidth, 1e-3, "-maxw");
 			}
 
 		};
@@ -219,7 +220,7 @@ public class MainTest {
 			@Override
 			public void validate(SVGConverter c) {
 				float maxHeight = c.getMaxHeight();
-				assertEquals("-maxh", 345.67, maxHeight, 1e-3);
+				assertEquals(345.67, maxHeight, 1e-3, "-maxh");
 			}
 		};
 		t.runTest("-maxh 345.67");
@@ -231,8 +232,8 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				Rectangle2D aoi = c.getArea();
 				Rectangle2D.Float eAoi = new Rectangle2D.Float(5, 10, 20, 30);
-				assertEquals("-a", eAoi, aoi);
-				assertEquals("-a", toString(eAoi), toString(aoi));
+				assertEquals(eAoi, aoi, "-a");
+				assertEquals(toString(eAoi), toString(aoi), "-a");
 			}
 
 			public String toString(Rectangle2D r) {
@@ -253,8 +254,8 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				Color bg = c.getBackgroundColor();
 				Color eBg = new Color(200, 100, 50, 128); // Alpha is last
-				assertEquals("-bg", eBg, bg);
-				assertEquals("-bg", toString(eBg), toString(bg));
+				assertEquals(eBg, bg, "-bg");
+				assertEquals(toString(eBg), toString(bg), "-bg");
 			}
 
 			public String toString(Color c) {
@@ -275,7 +276,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				String cssMedia = c.getMediaType();
 				String eCssMedia = "projection";
-				assertEquals("-cssMedia", eCssMedia, cssMedia);
+				assertEquals(eCssMedia, cssMedia, "-cssMedia");
 			}
 		};
 		t.runTest("-cssMedia projection");
@@ -287,7 +288,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				String fontFamily = c.getDefaultFontFamily();
 				String eFontFamily = "Arial, Comic Sans MS";
-				assertEquals("-font-family", eFontFamily, fontFamily);
+				assertEquals(eFontFamily, fontFamily, "-font-family");
 			}
 
 			@Override
@@ -303,7 +304,7 @@ public class MainTest {
 			public void validate(SVGConverter c) {
 				String alternate = c.getAlternateStylesheet();
 				String eAlternate = "myAlternateStylesheet";
-				assertEquals("-cssAlternate", eAlternate, alternate);
+				assertEquals(eAlternate, alternate, "-cssAlternate");
 			}
 		};
 		t.runTest("-cssAlternate myAlternateStylesheet");
@@ -313,7 +314,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertTrue("-validate", c.getValidate());
+				assertTrue(c.getValidate(), "-validate");
 			}
 		};
 		t.runTest("-validate");
@@ -323,7 +324,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertTrue("-onload", c.getExecuteOnload());
+				assertTrue(c.getExecuteOnload(), "-onload");
 			}
 		};
 		t.runTest("-onload");
@@ -333,7 +334,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertEquals("-scripts", "text/jpython", c.getAllowedScriptTypes());
+				assertEquals("text/jpython", c.getAllowedScriptTypes(), "-scripts");
 			}
 		};
 		t.runTest("-scripts text/jpython");
@@ -343,7 +344,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertFalse("-anyScriptOrigin", c.getConstrainScriptOrigin());
+				assertFalse(c.getConstrainScriptOrigin(), "-anyScriptOrigin");
 			}
 		};
 		t.runTest("-anyScriptOrigin");
@@ -353,7 +354,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertTrue("-scriptSecurityOff", c.getSecurityOff());
+				assertTrue(c.getSecurityOff(), "-scriptSecurityOff");
 			}
 		};
 		t.runTest("-scriptSecurityOff");
@@ -362,7 +363,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertEquals("-lang", "fr", c.getLanguage());
+				assertEquals("fr", c.getLanguage(), "-lang");
 			}
 		};
 		t.runTest("-lang fr");
@@ -371,7 +372,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertEquals("-cssUser", "myStylesheet.css", c.getUserStylesheet());
+				assertEquals("myStylesheet.css", c.getUserStylesheet(), "-cssUser");
 			}
 		};
 		t.runTest("-cssUser myStylesheet.css");
@@ -380,7 +381,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertEquals("-dpi", 5f, c.getPixelUnitToMillimeter(), 1e-3);
+				assertEquals(5f, c.getPixelUnitToMillimeter(), 1e-3, "-dpi");
 			}
 		};
 		t.runTest("-dpi 5.08");
@@ -389,7 +390,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertEquals("-q", .5f, c.getQuality(), 1e-3);
+				assertEquals(.5f, c.getQuality(), 1e-3, "-q");
 			}
 		};
 		t.runTest("-q .5");
@@ -398,7 +399,7 @@ public class MainTest {
 		t = new MainConfigTest() {
 			@Override
 			public void validate(SVGConverter c) {
-				assertEquals("-indexed", 8, c.getIndexed());
+				assertEquals(8, c.getIndexed(), "-indexed");
 			}
 		};
 		t.runTest("-indexed 8");
@@ -522,11 +523,11 @@ abstract class AbstractMainTest {
 	}
 
 	void assertError(String expectedErrorCode, String errorCode) {
-		assertEquals(ERROR_UNEXPECTED_ERROR_CODE, expectedErrorCode, errorCode);
+		assertEquals(expectedErrorCode, errorCode, ERROR_UNEXPECTED_ERROR_CODE);
 	}
 
 	void assertUsagePrinted() {
-		assertTrue("Usage was not printed", usagePrinted);
+		assertTrue(usagePrinted, "Usage was not printed");
 	}
 
 	String[] makeArgsArray(String args) {
@@ -551,7 +552,7 @@ class MainIllegalArgTest extends AbstractMainTest {
 
 	@Override
 	void onError(String errorCode, Object[] errorArgs) {
-		assertEquals(ERROR_UNEXPECTED_ERROR_CODE, Main.ERROR_ILLEGAL_ARGUMENT, errorCode);
+		assertEquals(Main.ERROR_ILLEGAL_ARGUMENT, errorCode, ERROR_UNEXPECTED_ERROR_CODE);
 	}
 
 	@Override

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/apps/rasterizer/SVGConverterTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/apps/rasterizer/SVGConverterTest.java
@@ -19,8 +19,8 @@
 
 package io.sf.carte.echosvg.apps.rasterizer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.Color;
 import java.awt.Rectangle;
@@ -35,6 +35,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestLocations;
 import io.sf.carte.echosvg.test.svg.ImageCompareTest;
@@ -85,7 +87,7 @@ public class SVGConverterTest {
 	///////////////////////////////////////////////////////////////////////
 	// Configuration tests
 	///////////////////////////////////////////////////////////////////////
-	@org.junit.Test
+	@Test
 	public void testTranscoderConfig() throws SVGConverterException, IOException {
 		AbstractConfigTest t = null;
 
@@ -108,7 +110,7 @@ public class SVGConverterTest {
 	//
 	// Checks that the proper hints are used
 	//
-	@org.junit.Test
+	@Test
 	public void testHintsConfig() throws SVGConverterException, IOException {
 		// HintsConfigTest.KEY_AOI
 		HintsConfigTest t = new HintsConfigTest(new Object[][] { { SVGAbstractTranscoder.KEY_AOI, new Rectangle(40, 50, 40, 80) } }) {
@@ -265,7 +267,7 @@ public class SVGConverterTest {
 	//
 	// Check sources
 	//
-	@org.junit.Test
+	@Test
 	public void testSourcesConfig() throws SVGConverterException, IOException {
 		// SourcesConfigTest.SimpleList
 		SourcesConfigTest t = new SourcesConfigTest(
@@ -283,7 +285,7 @@ public class SVGConverterTest {
 		t.runTest();
 	}
 
-	@org.junit.Test
+	@Test
 	public void testDestConfig() throws SVGConverterException, IOException {
 		//
 		// Check destination
@@ -310,7 +312,7 @@ public class SVGConverterTest {
 		t.runTest();
 	}
 
-	@org.junit.Test
+	@Test
 	public void testOperation() throws SVGConverterException, IOException {
 		//
 		// Check that complete process goes without error
@@ -334,7 +336,7 @@ public class SVGConverterTest {
 	// Configuration error test. These tests check that the expected
 	// error gets reported for a given mis-configuration
 	///////////////////////////////////////////////////////////////////////
-	@org.junit.Test
+	@Test
 	public void testConfigError() throws SVGConverterException, IOException {
 		// ConfigErrorTest.ERROR_NO_SOURCES_SPECIFIED
 		ConfigErrorTest cet = new ConfigErrorTest(SVGConverter.ERROR_NO_SOURCES_SPECIFIED) {
@@ -487,7 +489,7 @@ public class SVGConverterTest {
 	// Test that files are created as expected and are producing the
 	// expected result.
 	//
-	@org.junit.Test
+	@Test
 	public void testOutput() throws SVGConverterException, IOException {
 		// Plain file
 		// OutputTest.plain
@@ -497,7 +499,7 @@ public class SVGConverterTest {
 
 	}
 
-	@org.junit.Test
+	@Test
 	public void testOutputView() throws SVGConverterException, IOException {
 		// File with reference
 		// OutputTest.reference
@@ -919,7 +921,7 @@ class ConfigErrorTest implements SVGConverterController {
 			foundErrorCode = e.getErrorCode();
 		}
 
-		assertEquals("Expected error code " + errorCode, errorCode, foundErrorCode);
+		assertEquals(errorCode, foundErrorCode, "Expected error code " + errorCode);
 	}
 
 	protected void configure(SVGConverter c) {

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/EcmaLoadTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/EcmaLoadTest.java
@@ -22,8 +22,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks that ECMA Scripts which should be loaded are indeed loaded.
@@ -35,7 +35,7 @@ import org.junit.Test;
 @SuppressWarnings({ "deprecation", "removal" })
 public class EcmaLoadTest {
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/EcmaNoLoadTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/EcmaNoLoadTest.java
@@ -22,8 +22,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.SVGOnLoadExceptionTest;
 
@@ -37,7 +37,7 @@ import io.sf.carte.echosvg.test.svg.SVGOnLoadExceptionTest;
 @SuppressWarnings({ "deprecation", "removal" })
 public class EcmaNoLoadTest {
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/ExternalResourcesTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/ExternalResourcesTest.java
@@ -18,15 +18,16 @@
  */
 package io.sf.carte.echosvg.bridge;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.StringTokenizer;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -157,12 +158,12 @@ public class ExternalResourcesTest implements ErrorConstants {
 	 * should cause a SecurityException. If so, the test passes. Otherwise, the test
 	 * will fail
 	 */
-	@org.junit.Test
+	@Test
 	public void testSecure() throws IOException {
 		runTest("externalResourcesAccess", true);
 	}
 
-	@org.junit.Test
+	@Test
 	public void testUnsecure() throws IOException {
 		runTest("externalResourcesAccess", false);
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/JarLoadTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/JarLoadTest.java
@@ -22,8 +22,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks that JAR Scripts which should be loaded are indeed loaded.
@@ -37,7 +37,7 @@ public class JarLoadTest {
 
 	private static final String scriptsType = "application/java-archive";
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/JarNoLoadTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/JarNoLoadTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.bridge;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.SVGOnLoadExceptionTest;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/LoadPermissionsTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/LoadPermissionsTest.java
@@ -22,9 +22,9 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.SVGOnLoadExceptionTest;
 
@@ -36,7 +36,7 @@ import io.sf.carte.echosvg.test.svg.SVGOnLoadExceptionTest;
 @SuppressWarnings({ "deprecation", "removal" })
 public class LoadPermissionsTest {
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
@@ -100,7 +100,7 @@ public class LoadPermissionsTest {
 	/*
 	 * This should generate only a warning, according to Batik (bridge/unitTesting.xml)
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public void testBridgeExceptionInvalidCSS() throws Exception {
 		runTest("application/java-archive", "bridge/error/css-invalid", "ANY", false, false,
@@ -282,7 +282,7 @@ public class LoadPermissionsTest {
 	}
 
 	// This should display a broken-image image, no exception
-	@Ignore
+	@Disabled
 	@Test
 	public void testBridgeExceptionImageBadURL() throws Exception {
 		runTest("application/java-archive", "bridge/error/image-badurl", "ANY", false, false,
@@ -407,7 +407,7 @@ public class LoadPermissionsTest {
 	}
 
 	// This is not an error according to 13.2.4
-	@Ignore
+	@Disabled
 	@Test
 	public void testBridgeExceptionEmptyRadialGradient() throws Exception {
 		runTest("application/java-archive", "bridge/error/radialGradient-empty", "ANY", false, false,
@@ -433,7 +433,7 @@ public class LoadPermissionsTest {
 	}
 
 	// This is not an error according to 13.2.3
-	@Ignore
+	@Disabled
 	@Test
 	public void testBridgeExceptionRadialGradientRZero() throws Exception {
 		runTest("application/java-archive", "bridge/error/radialGradient-r-zero", "ANY", false, false,

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/PermissionsTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/PermissionsTest.java
@@ -22,8 +22,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks the permissions applied to ECMA and Jar Scripts.
@@ -33,7 +33,7 @@ import org.junit.Test;
 @SuppressWarnings({ "deprecation", "removal" })
 public class PermissionsTest {
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/ScriptSelfTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/bridge/ScriptSelfTest.java
@@ -19,7 +19,7 @@
 
 package io.sf.carte.echosvg.bridge;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.security.AccessController;
 import java.security.PrivilegedActionException;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/css/dom/EcmaScriptCSSDOMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/css/dom/EcmaScriptCSSDOMTest.java
@@ -19,7 +19,7 @@
 
 package io.sf.carte.echosvg.css.dom;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.SelfContainedSVGOnLoadTest;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/css/engine/value/PropertyManagerTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/css/engine/value/PropertyManagerTest.java
@@ -19,13 +19,13 @@
 
 package io.sf.carte.echosvg.css.engine.value;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.util.StringTokenizer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.doc.style.css.nsac.LexicalUnit;
 import io.sf.carte.doc.style.css.nsac.Parser;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/AppendChildTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/AppendChildTest.java
@@ -18,13 +18,13 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/AttrIsIdTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/AttrIsIdTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/AttrTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/AttrTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/CloneElementTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/CloneElementTest.java
@@ -18,13 +18,13 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DOMUtilitiesCharacterEscaping.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DOMUtilitiesCharacterEscaping.java
@@ -18,14 +18,14 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.DOMImplementation;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DocumentAdoptNodeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DocumentAdoptNodeTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DocumentNormalizeDocumentTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DocumentNormalizeDocumentTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMConfiguration;
 import org.w3c.dom.DOMError;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DocumentRenameNodeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/DocumentRenameNodeTest.java
@@ -18,10 +18,10 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/EcmaScriptDOMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/EcmaScriptDOMTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.SelfContainedSVGOnLoadTest;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/ElementSetIdAttributeNSTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/ElementSetIdAttributeNSTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/ElementTraversalTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/ElementTraversalTest.java
@@ -19,15 +19,15 @@
 
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/EventTargetAddEventListenerNSTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/EventTargetAddEventListenerNSTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/GetElementsByTagNameNSTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/GetElementsByTagNameNSTest.java
@@ -18,12 +18,12 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/HasChildNodesTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/HasChildNodesTest.java
@@ -18,12 +18,12 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeBaseURITest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeBaseURITest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeCompareDocumentPositionTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeCompareDocumentPositionTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeGetUserDataTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeGetUserDataTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeIsEqualNodeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeIsEqualNodeTest.java
@@ -19,14 +19,14 @@
 
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeTextContentTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NodeTextContentTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NullNamespaceTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/NullNamespaceTest.java
@@ -18,13 +18,13 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/RemoveAttributeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/RemoveAttributeTest.java
@@ -18,12 +18,12 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/ReplaceChildTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/ReplaceChildTest.java
@@ -18,14 +18,14 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/SerializationTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/SerializationTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,7 +29,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import io.sf.carte.echosvg.dom.util.DocumentFactory;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/SetAttributeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/SetAttributeTest.java
@@ -19,13 +19,13 @@
 
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/TextReplaceWholeTextTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/TextReplaceWholeTextTest.java
@@ -18,10 +18,10 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Text;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/TextWholeTextTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/TextWholeTextTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.dom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/CloneNodeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/CloneNodeTest.java
@@ -18,13 +18,13 @@
  */
 package io.sf.carte.echosvg.dom.svg;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/EcmaScriptSVGDOMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/EcmaScriptSVGDOMTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.dom.svg;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.SelfContainedSVGOnLoadTest;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/ImportNodeTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/ImportNodeTest.java
@@ -18,13 +18,13 @@
  */
 package io.sf.carte.echosvg.dom.svg;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/geom/RectListManagerTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/geom/RectListManagerTest.java
@@ -19,7 +19,7 @@
 
 package io.sf.carte.echosvg.ext.awt.geom;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.Rectangle;
 import java.io.BufferedReader;
@@ -37,7 +37,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestLocations;
 import io.sf.carte.echosvg.util.Base64Test;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/image/codec/png/PNGEncoderTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/image/codec/png/PNGEncoderTest.java
@@ -19,7 +19,7 @@
 
 package io.sf.carte.echosvg.ext.awt.image.codec.png;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
@@ -32,7 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test validates the PNGEncoder operation. It creates a BufferedImage,
@@ -98,7 +98,7 @@ public class PNGEncoderTest {
 		}
 
 		// Compare images
-		assertTrue("Images are not identical", checkIdentical(image, decodedImage));
+		assertTrue(checkIdentical(image, decodedImage), "Images are not identical");
 	}
 
 	/**

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/image/spi/ImageTagRegistryTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/image/spi/ImageTagRegistryTest.java
@@ -18,14 +18,14 @@
  */
 package io.sf.carte.echosvg.ext.awt.image.spi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.color.ColorSpace;
 import java.awt.image.RenderedImage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.bridge.SVGBrokenLinkProvider;
 import io.sf.carte.echosvg.ext.awt.image.renderable.Filter;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/image/spi/JDKRegistryEntryTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/ext/awt/image/spi/JDKRegistryEntryTest.java
@@ -18,13 +18,13 @@
  */
 package io.sf.carte.echosvg.ext.awt.image.spi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.color.ColorSpace;
 import java.awt.image.RenderedImage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.bridge.SVGBrokenLinkProvider;
 import io.sf.carte.echosvg.ext.awt.image.renderable.Filter;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/gvt/TextSelectionTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/gvt/TextSelectionTest.java
@@ -19,12 +19,12 @@
 
 package io.sf.carte.echosvg.gvt;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGTextContentElement;
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/LengthParserFailureTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/LengthParserFailureTest.java
@@ -18,11 +18,11 @@
  */
 package io.sf.carte.echosvg.parser;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * To test the length parser.

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/LengthParserTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/LengthParserTest.java
@@ -18,11 +18,11 @@
  */
 package io.sf.carte.echosvg.parser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * To test the length parser.

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/PathParserFailureTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/PathParserFailureTest.java
@@ -18,11 +18,11 @@
  */
 package io.sf.carte.echosvg.parser;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * To test the path parser.

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/PathParserTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/PathParserTest.java
@@ -18,11 +18,11 @@
  */
 package io.sf.carte.echosvg.parser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * To test the path parser.

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/TransformListParserTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/parser/TransformListParserTest.java
@@ -19,11 +19,11 @@
 
 package io.sf.carte.echosvg.parser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * To test the transform list parser.

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/script/rhino/RhinoTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/script/rhino/RhinoTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.script.rhino;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Checks the permissions applied to Rhino Scripts.

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/Bug21259Test.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/Bug21259Test.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.svggen;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -26,6 +26,7 @@ import java.awt.Rectangle;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -41,7 +42,7 @@ import io.sf.carte.echosvg.anim.dom.SVGDOMImplementation;
  */
 public class Bug21259Test {
 
-	@org.junit.Test
+	@Test
 	public void test() throws SVGGraphics2DIOException {
 		Document document = SVGDOMImplementation.getDOMImplementation()
 				.createDocument(SVGDOMImplementation.SVG_NAMESPACE_URI, "svg", null);

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/DoubleStringTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/DoubleStringTest.java
@@ -20,6 +20,7 @@ package io.sf.carte.echosvg.svggen;
 
 import java.awt.geom.Rectangle2D;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 
@@ -34,7 +35,7 @@ import io.sf.carte.echosvg.dom.GenericDOMImplementation;
  */
 public class DoubleStringTest {
 
-	@org.junit.Test
+	@Test
 	public void test() {
 		// Get a DOMImplementation
 		DOMImplementation domImpl = GenericDOMImplementation.getDOMImplementation();

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/GetRootTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/GetRootTest.java
@@ -18,12 +18,13 @@
  */
 package io.sf.carte.echosvg.svggen;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.Dimension;
 import java.awt.Font;
 import java.io.StringWriter;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 
@@ -44,7 +45,7 @@ public class GetRootTest {
 
 	private static final Dimension CANVAS_SIZE = new Dimension(300, 400);
 
-	@org.junit.Test
+	@Test
 	public void test() throws SVGGraphics2DIOException {
 		// First, use the no-argument getRoot
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/SVGAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/SVGAccuracyTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.svggen;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.Dimension;
 import java.awt.Font;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/SVGAccuracyTestValidator.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/SVGAccuracyTestValidator.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.svggen;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.UnknownHostException;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Validates the operation of the <code>SVGAccuractyTest</code> class
@@ -41,7 +43,7 @@ public class SVGAccuracyTestValidator {
 	 * Checks that test works if SVG and reference SVG are identical
 	 * @throws IOException 
 	 */
-	@org.junit.Test
+	@Test
 	public void testSVGAccuracyValidator() throws Exception {
 		new PainterWithException().test();
 		new NullReferenceURL().test();

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/SVGGeneratorTests.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/SVGGeneratorTests.java
@@ -18,7 +18,8 @@
  */
 package io.sf.carte.echosvg.svggen;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.awt.Font;
 import java.awt.FontFormatException;
@@ -27,8 +28,8 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.test.TestLocations;
@@ -78,79 +79,79 @@ public class SVGGeneratorTests {
 		GENERATOR_REFERENCE_BASE = TestLocations.PROJECT_ROOT_URL + "test-references/io/sf/carte/echosvg/svggen/";
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws FontFormatException, IOException {
 		TestFonts.loadTestFonts();
 	}
 
-	@org.junit.Test
+	@Test
 	public void testATransform() throws Exception {
 		runTests("ATransform");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testAttributedCharacterIterator() throws Exception {
 		runTests("AttributedCharacterIterator");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBasicShapes() throws Exception {
 		runTests("BasicShapes");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBasicShapes2() throws Exception {
 		runTests("BasicShapes2");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBStroke() throws Exception {
 		runTests("BStroke");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBug4389() throws Exception {
 		runTests("Bug4389");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBug4945() throws Exception {
 		runTests("Bug4945");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBug6535() throws Exception {
 		runTests("Bug6535");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testBug17965() throws Exception {
 		runTests("Bug17965");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testClip() throws Exception {
 		runTests("Clip");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testColor1() throws Exception {
 		runTests("Color1");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testColor2() throws Exception {
 		runTests("Color2");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testDrawImage() throws Exception {
 		runTests("DrawImage");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testFont1() throws Exception {
-		Assume.assumeTrue("Test uses logical fonts, reference data is for Windows", isWindows());
+		assumeTrue(isWindows(), "Test uses logical fonts, reference data is for Windows");
 		runTests("Font1");
 	}
 
@@ -159,73 +160,73 @@ public class SVGGeneratorTests {
 		return osName.startsWith("Windows");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testFontDecoration() throws Exception {
 		runTests("FontDecoration");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testGVector() throws Exception {
 		runTests("GVector");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testGradient() throws Exception {
 		runTests("Gradient");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testGraphicObjects() throws Exception {
 		runTests("GraphicObjects");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testIdentityTest() throws Exception {
 		runTests("IdentityTest");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testLookup() throws Exception {
 		runTests("Lookup");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testNegativeLengths() throws Exception {
 		runTests("NegativeLengths");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testPaints() throws Exception {
 		runTests("Paints");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testRHints() throws Exception {
 		TestFonts.registerFont(Font.TRUETYPE_FONT, "Anton-Regular.ttf");
 		runTests("RHints");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testRescale() throws Exception {
 		runTests("Rescale");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testShearTest() throws Exception {
 		runTests("ShearTest");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testTexture() throws Exception {
 		runTests("Texture");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testTextSpacePreserve() throws Exception {
 		runTests("TextSpacePreserve");
 	}
 
-	@org.junit.Test
+	@Test
 	public void testTransformCollapse() throws Exception {
 		runTests("TransformCollapse");
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/ShowGraphics2DOutput.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/svggen/ShowGraphics2DOutput.java
@@ -18,13 +18,14 @@
  */
 package io.sf.carte.echosvg.svggen;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGDocument;
@@ -45,7 +46,7 @@ import io.sf.carte.echosvg.bridge.UserAgentAdapter;
  */
 public class ShowGraphics2DOutput {
 
-	@org.junit.Test
+	@Test
 	public void test() {
 		DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
 		String svgNS = SVGDOMImplementation.SVG_NAMESPACE_URI;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/swing/test/SwingMemoryLeakTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/swing/test/SwingMemoryLeakTest.java
@@ -21,8 +21,8 @@ package io.sf.carte.echosvg.swing.test;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.svg.AbstractRenderingAccuracyTest;
 
@@ -54,13 +54,13 @@ public class SwingMemoryLeakTest {
 		new JSVGInterruptTest().runTest("samples/anne.svg");
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testInterrupt2() throws Exception {
 		new JSVGInterruptTest().runTest("samples/sydney.svg");
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testInterrupt3() throws Exception {
 		new JSVGInterruptTest().runTest("samples/mines.svg");

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/image/ImageComparatorTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/image/ImageComparatorTest.java
@@ -13,15 +13,15 @@
  */
 package io.sf.carte.echosvg.test.image;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.ext.awt.image.renderable.Filter;
 import io.sf.carte.echosvg.ext.awt.image.spi.ImageTagRegistry;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/AbstractRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/AbstractRenderingAccuracyTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.test.svg;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/JSVGRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/JSVGRenderingAccuracyTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.test.svg;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGAlternateStyleSheetRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGAlternateStyleSheetRenderingAccuracyTest.java
@@ -20,6 +20,8 @@ package io.sf.carte.echosvg.test.svg;
 
 import java.net.MalformedURLException;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.image.ImageTranscoder;
 
@@ -33,7 +35,7 @@ import io.sf.carte.echosvg.transcoder.image.ImageTranscoder;
  */
 public class SVGAlternateStyleSheetRenderingAccuracyTest extends ParameterizedRenderingAccuracyTest {
 
-	@org.junit.Test
+	@Test
 	public void test() throws MalformedURLException {
 		runTest("samples/tests/spec/styling/alternateStylesheet.svg", "Hot");
 		runTest("samples/tests/spec/styling/alternateStylesheet.svg", "Cold");

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGMediaRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGMediaRenderingAccuracyTest.java
@@ -20,7 +20,7 @@ package io.sf.carte.echosvg.test.svg;
 
 import java.net.MalformedURLException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.image.ImageTranscoder;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGOnLoadExceptionTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGOnLoadExceptionTest.java
@@ -18,8 +18,8 @@
  */
 package io.sf.carte.echosvg.test.svg;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FilePermission;
@@ -459,7 +459,7 @@ public class SVGOnLoadExceptionTest {
 		String exname = e.getClass().getName();
 		if (!exceptionMatches(e.getClass(), getExpectedExceptionClass())) {
 			e.printStackTrace();
-			assertEquals("Unexpected exception from " + fileName + ',', getExpectedExceptionClass(), exname);
+			assertEquals(getExpectedExceptionClass(), exname, "Unexpected exception from " + fileName + ',');
 		}
 	}
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGReferenceRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SVGReferenceRenderingAccuracyTest.java
@@ -21,7 +21,7 @@ package io.sf.carte.echosvg.test.svg;
 import java.io.File;
 import java.net.MalformedURLException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base class for tests which take an additional parameter in addition to the

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SamplesRenderingTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SamplesRenderingTest.java
@@ -20,9 +20,9 @@ package io.sf.carte.echosvg.test.svg;
 
 import java.io.IOException;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.transcoder.TranscoderException;
@@ -41,7 +41,7 @@ import io.sf.carte.echosvg.transcoder.TranscoderException;
  */
 public class SamplesRenderingTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 		TestFonts.loadTestFonts();
 	}
@@ -76,7 +76,7 @@ public class SamplesRenderingTest {
 		test("samples/batikFX.svg");
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testBatikLogo() throws TranscoderException, IOException {
 		test("samples/batikLogo.svg");
@@ -252,7 +252,7 @@ public class SamplesRenderingTest {
 	}
 
 	// See issue #27
-	@Ignore
+	@Disabled
 	@Test
 	public void testFilterRegion() throws TranscoderException, IOException {
 		testNV("samples/tests/spec12/filters/filterRegion.svg");
@@ -356,7 +356,7 @@ public class SamplesRenderingTest {
 	}
 
 	// Issue #28: "Unable to convolve src image", see also BATIK-1280
-	@Ignore
+	@Disabled
 	@Test
 	public void testFilterFeConvolveMatrix() throws TranscoderException, IOException {
 		test("samples/tests/spec/filters/feConvolveMatrix.svg");
@@ -420,7 +420,7 @@ public class SamplesRenderingTest {
 	/*
 	 * Fonts
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public void testFont() throws TranscoderException, IOException {
 		test("samples/tests/spec/fonts/echosvgFont.svg");
@@ -468,7 +468,7 @@ public class SamplesRenderingTest {
 	/*
 	 * Can't make this one work
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public void testFontFace() throws TranscoderException, IOException {
 		test("samples/tests/spec/fonts/fontFace.svg");
@@ -494,7 +494,7 @@ public class SamplesRenderingTest {
 		test("samples/tests/spec/fonts/fontGlyphsD.svg");
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testFontKerning() throws TranscoderException, IOException {
 		test("samples/tests/spec/fonts/fontKerning.svg");
@@ -983,7 +983,7 @@ public class SamplesRenderingTest {
 	}
 
 	// See issue #31
-	@Ignore
+	@Disabled
 	@Test
 	public void testTextDecoration2() throws TranscoderException, IOException {
 		test("samples/tests/spec/text/textDecoration2.svg");
@@ -1128,7 +1128,7 @@ public class SamplesRenderingTest {
 	}
 
 	// See issue #30
-	@Ignore
+	@Disabled
 	@Test
 	public void testScriptEnclosureList2() throws TranscoderException, IOException {
 		test("samples/tests/spec/scripting/enclosureList2.svg");
@@ -1450,7 +1450,7 @@ public class SamplesRenderingTest {
 		testDynamicUpdate("samples/tests/spec/scripting/setProperty.svg");
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testStyling() throws TranscoderException, IOException {
 		testDynamicUpdate("samples/tests/spec/scripting/styling.svg");

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SelfContainedSVGOnLoadTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SelfContainedSVGOnLoadTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.test.svg;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -235,7 +235,7 @@ public class SelfContainedSVGOnLoadTest {
 
 		if (!TEST_RESULT_PASSED.equals(result)) {
 			String errorCode = testResult.getAttributeNS(null, "errorCode");
-			assertEquals("Failed with unexpected error code,", expectedError, errorCode);
+			assertEquals(expectedError, errorCode, "Failed with unexpected error code,");
 		} else if (expectedError.length() > 0) {
 			fail("Script was loaded, but expected error: " + expectedError);
 		}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SelfContainedSVGOnLoadTestValidator.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SelfContainedSVGOnLoadTestValidator.java
@@ -18,11 +18,11 @@
  */
 package io.sf.carte.echosvg.test.svg;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.FileNotFoundException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test validates the operation of SelfContainedSVGOnLoadTest. It is a test

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/StyleBypassRenderingTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/StyleBypassRenderingTest.java
@@ -28,8 +28,8 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
@@ -59,7 +59,7 @@ public class StyleBypassRenderingTest {
 
 	private final String PRINT_MEDIUM = "print";
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 		TestFonts.loadTestFonts();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/TranscoderInputTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/TranscoderInputTest.java
@@ -19,7 +19,7 @@
 
 package io.sf.carte.echosvg.transcoder;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,7 +30,7 @@ import java.net.URL;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.xml.sax.XMLReader;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/AOITest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/AOITest.java
@@ -22,6 +22,8 @@ import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
@@ -51,7 +53,7 @@ public class AOITest extends AbstractImageTranscoderTest {
 	/** The height of the image. */
 	private float imgHeight;
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		testAOI("samples/anne.svg", "test-references/io/sf/carte/echosvg/transcoder/image/anneNW.png", 0f, 0f, 225f,
 				250f);

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/AbstractImageTranscoderTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/AbstractImageTranscoderTest.java
@@ -18,7 +18,7 @@
  */
 package io.sf.carte.echosvg.transcoder.image;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/AlternateStylesheetTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/AlternateStylesheetTest.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
@@ -50,7 +50,7 @@ public class AlternateStylesheetTest extends AbstractImageTranscoderTest {
 	/** The alternate stylesheet to use. */
 	private String alternateStylesheet;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws FontFormatException, IOException {
 		TestFonts.loadTestFonts();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/BackgroundColorTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/BackgroundColorTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -48,7 +49,7 @@ public class BackgroundColorTest extends AbstractImageTranscoderTest {
 	 * Runs a new <code>BackgroundColorTest</code>.
 	 * @throws TranscoderException 
 	 */
-	@org.junit.Test
+	@Test
 	public void testBackgroundColor() throws TranscoderException {
 		runTest();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/DOMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/DOMTest.java
@@ -23,6 +23,7 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -41,7 +42,7 @@ import io.sf.carte.echosvg.transcoder.TranscoderOutput;
  */
 public class DOMTest extends AbstractImageTranscoderTest {
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		runTest();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/DefaultFontFamilyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/DefaultFontFamilyTest.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
@@ -41,7 +41,7 @@ import io.sf.carte.echosvg.transcoder.TranscodingHints.Key;
  */
 public class DefaultFontFamilyTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws FontFormatException, IOException {
 		TestFonts.loadTestFonts();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/DimensionTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/DimensionTest.java
@@ -21,6 +21,8 @@ package io.sf.carte.echosvg.transcoder.image;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
@@ -48,7 +50,7 @@ public class DimensionTest extends AbstractImageTranscoderTest {
 	/** The height of the image. */
 	private Float height;
 
-	@org.junit.Test
+	@Test
 	public void test()
 			throws TranscoderException {
 		testDimension("samples/anne.svg", "test-references/io/sf/carte/echosvg/transcoder/image/anneW200.png", 200, -1);

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/GenericDocumentTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/GenericDocumentTest.java
@@ -21,6 +21,7 @@ package io.sf.carte.echosvg.transcoder.image;
 import java.io.IOException;
 import java.net.URL;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 
@@ -44,7 +45,7 @@ public class GenericDocumentTest extends AbstractImageTranscoderTest {
 	/** The URI of the reference image. */
 	private String refImageURI;
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		testGenericDocument("samples/anne.svg", "test-references/samples/anne.png");
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/InputStreamTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/InputStreamTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
 
@@ -40,7 +42,7 @@ public class InputStreamTest extends AbstractImageTranscoderTest {
 	/** The URI of the reference image. */
 	private String refImageURI;
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		testInputStream("samples/anne.svg", "test-references/samples/anne.png");
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/LanguageTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/LanguageTest.java
@@ -21,6 +21,8 @@ package io.sf.carte.echosvg.transcoder.image;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
@@ -47,7 +49,7 @@ public class LanguageTest extends AbstractImageTranscoderTest {
 	/**
 	 * Runs a new <code>LanguageTest</code>.
 	 */
-	@org.junit.Test
+	@Test
 	public void testLanguage() throws TranscoderException {
 		testLanguage("test-resources/io/sf/carte/echosvg/transcoder/image/resources/language.svg",
 				"test-references/io/sf/carte/echosvg/transcoder/image/languageEn.png", "en");

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/MaxDimensionTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/MaxDimensionTest.java
@@ -21,6 +21,8 @@ package io.sf.carte.echosvg.transcoder.image;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
@@ -50,7 +52,7 @@ public class MaxDimensionTest extends AbstractImageTranscoderTest {
 	/** The height of the image. */
 	private float height = Float.NaN;
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		testMaxDimension("samples/anne.svg", "test-references/io/sf/carte/echosvg/transcoder/image/anneMaxW200.png",
 				200, -1);

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/MediaTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/MediaTest.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestFonts;
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
@@ -50,7 +50,7 @@ public class MediaTest extends AbstractImageTranscoderTest {
 	/** The CSS media to use. */
 	private String media;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws FontFormatException, IOException {
 		TestFonts.loadTestFonts();
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/ParameterizedDOMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/ParameterizedDOMTest.java
@@ -20,6 +20,7 @@ package io.sf.carte.echosvg.transcoder.image;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import io.sf.carte.echosvg.anim.dom.SAXSVGDocumentFactory;
@@ -41,7 +42,7 @@ public class ParameterizedDOMTest extends AbstractImageTranscoderTest {
 	/** The URI of the reference image. */
 	private String refImageURI;
 
-	@org.junit.Test
+	@Test
 	public void test()
 			throws TranscoderException {
 		testParameterizedDOM("samples/anne.svg", "test-references/samples/anne.png");

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/PixelToMMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/PixelToMMTest.java
@@ -21,6 +21,8 @@ package io.sf.carte.echosvg.transcoder.image;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
@@ -45,13 +47,13 @@ public class PixelToMMTest extends AbstractImageTranscoderTest {
 	/** The pixel to mm factor. */
 	private float px2mm;
 
-	@org.junit.Test
+	@Test
 	public void test96dpi() throws TranscoderException {
 		testPixelToMM("test-resources/io/sf/carte/echosvg/transcoder/image/resources/px2mm.svg",
 				"test-references/io/sf/carte/echosvg/transcoder/image/px2mm96dpi.png", 0.2645833f);
 	}
 
-	@org.junit.Test
+	@Test
 	public void test72dpi() throws TranscoderException {
 		testPixelToMM("test-resources/io/sf/carte/echosvg/transcoder/image/resources/px2mm.svg",
 				"test-references/io/sf/carte/echosvg/transcoder/image/px2mm72dpi.png", 0.3528f);

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/ReaderTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/ReaderTest.java
@@ -23,6 +23,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
 
@@ -41,7 +43,7 @@ public class ReaderTest extends AbstractImageTranscoderTest {
 	/** The URI of the reference image. */
 	private String refImageURI;
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		testReader("samples/anne.svg", "test-references/samples/anne.png");
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/URITest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/image/URITest.java
@@ -19,6 +19,8 @@
 
 package io.sf.carte.echosvg.transcoder.image;
 
+import org.junit.jupiter.api.Test;
+
 import io.sf.carte.echosvg.transcoder.TranscoderException;
 import io.sf.carte.echosvg.transcoder.TranscoderInput;
 
@@ -37,7 +39,7 @@ public class URITest extends AbstractImageTranscoderTest {
 	/** The URI of the reference image. */
 	private String refImageURI;
 
-	@org.junit.Test
+	@Test
 	public void test() throws TranscoderException {
 		testURI("samples/anne.svg", "test-references/samples/anne.png");
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/wmf/WMFAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/transcoder/wmf/WMFAccuracyTest.java
@@ -18,7 +18,8 @@
  */
 package io.sf.carte.echosvg.transcoder.wmf;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.awt.GraphicsEnvironment;
 import java.io.ByteArrayOutputStream;
@@ -30,8 +31,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.sf.carte.echosvg.test.TestLocations;
 import io.sf.carte.echosvg.test.TestUtil;
@@ -87,8 +87,8 @@ public class WMFAccuracyTest {
 
 	@Test
 	public void testBlackShapes() throws IOException, TranscoderException {
-		Assume.assumeTrue("'Courier' font is not available", isFontAvailable("Courier"));
-		Assume.assumeTrue("'System' font is not available", isFontAvailable("System"));
+		assumeTrue(isFontAvailable("Courier"), "'Courier' font is not available");
+		assumeTrue(isFontAvailable("System"), "'System' font is not available");
 		runTest("samples/tests/resources/wmf/black_shapes.wmf");
 	}
 
@@ -99,26 +99,26 @@ public class WMFAccuracyTest {
 
 	@Test
 	public void testNegApmText1() throws IOException, TranscoderException {
-		Assume.assumeTrue("Arial font is not available", hasArial);
+		assumeTrue(hasArial, "Arial font is not available");
 		runTest("samples/tests/resources/wmf/negApmText1.wmf");
 	}
 
 	@Test
 	public void testNegApmText2() throws IOException, TranscoderException {
-		Assume.assumeTrue("Arial font is not available", hasArial);
+		assumeTrue(hasArial, "Arial font is not available");
 		runTest("samples/tests/resources/wmf/negApmText2.wmf");
 	}
 
 	@Test
 	public void testChart() throws IOException, TranscoderException {
-		Assume.assumeTrue("Arial font is not available", hasArial);
-		Assume.assumeTrue("'Courier New' font is not available", hasCourierNew);
+		assumeTrue(hasArial, "Arial font is not available");
+		assumeTrue(hasCourierNew, "'Courier New' font is not available");
 		runTest("samples/tests/resources/wmf/testChart.wmf");
 	}
 
 	@Test
 	public void testTextGreek() throws IOException, TranscoderException {
-		Assume.assumeTrue("'Courier New' font is not available", hasCourierNew);
+		assumeTrue(hasCourierNew, "'Courier New' font is not available");
 		runTest("samples/tests/resources/wmf/textGreek.wmf");
 	}
 

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/util/Base64Test.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/util/Base64Test.java
@@ -18,8 +18,8 @@
  */
 package io.sf.carte.echosvg.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,8 +28,8 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.URL;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test validates that the Base64 encoder/decoders work properly.
@@ -130,13 +130,13 @@ public class Base64Test {
 		performTest("B64.18", "ROUND", "tenByte", null);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testB64_19() throws Exception {
 		performTest("B64.19", "ENCODE", "small", "small.64");
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testB64_20() throws Exception {
 		performTest("B64.20", "DECODE", "small.64", "small");
@@ -218,7 +218,7 @@ public class Base64Test {
 
 		int mismatch = compareStreams(inIS, refIS, action.equals("ENCODE"));
 
-		assertEquals("Computed answer differed from reference at byte: " + mismatch, -1, mismatch);
+		assertEquals(-1, mismatch, "Computed answer differed from reference at byte: " + mismatch);
 	}
 
 	/**

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/util/ParsedURLDataTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/util/ParsedURLDataTest.java
@@ -18,12 +18,12 @@
  */
 package io.sf.carte.echosvg.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test validates that the ParsedURL class properly parses and cascades
@@ -76,7 +76,7 @@ public class ParsedURLDataTest {
 		String info = ("CT: " + purl.getContentType() + " CE: " + purl.getContentEncoding() + " DATA: " + sb + "URL: "
 				+ purl);
 
-		assertEquals("Bad URL: ", ref, info);
+		assertEquals(ref, info, "Bad URL: ");
 	}
 
 }

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/util/ParsedURLTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/util/ParsedURLTest.java
@@ -18,9 +18,9 @@
  */
 package io.sf.carte.echosvg.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test validates that the ParsedURL class properly parses and cascades
@@ -114,6 +114,6 @@ public class ParsedURLTest {
 			url = new ParsedURL(url, sub);
 		}
 
-		assertEquals("Bad URL: ", ref, url.toString());
+		assertEquals(ref, url.toString(), "Bad URL: ");
 	}
 }

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/util/RunnableQueueTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/util/RunnableQueueTest.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * RunnableQueue Stress Test

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/util/ThreadPounderTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/util/ThreadPounderTest.java
@@ -22,13 +22,14 @@ package io.sf.carte.echosvg.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ThreadPounderTest {
 
 	private StringBuilder buf = new StringBuilder(32);
 
-	@org.junit.Ignore
+	@Disabled
 	@Test
 	public void testThreadPounder() throws InterruptedException {
 		final int sz = 200;

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ echoXslVersion=2.7.3.1
 xmlApisVersion=1.4.01
 xmlgraphicsCommonsVersion=2.8
 htmlParserVersion=1.4.16
-junitVersion=4.13.2
+junitVersion=5.9.2
 jmhVersion=1.35
 # Allow Security Manager
 systemProp.java.security.manager=allow


### PR DESCRIPTION
The current test suite is based on JUnit 4, but that version is no longer under active development and the newest JUnit 5 is now mature.