### PR TITLE
Add `matches`, `querySelector`, `querySelectorAll` to DOM, and the `KEY_SVG_SELECTOR` transcoding hint

### DIFF
--- a/echosvg-bridge/src/main/java/io/sf/carte/echosvg/bridge/svg12/DefaultContentSelector.java
+++ b/echosvg-bridge/src/main/java/io/sf/carte/echosvg/bridge/svg12/DefaultContentSelector.java
@@ -25,6 +25,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import io.sf.carte.echosvg.anim.dom.XBLOMContentElement;
+import io.sf.carte.echosvg.dom.ArrayNodeList;
 
 /**
  * A class to handle content selection when the includes attribute is not
@@ -78,12 +79,7 @@ public class DefaultContentSelector extends AbstractContentSelector {
 	 * Implementation of NodeList that contains the nodes that matched this
 	 * selector.
 	 */
-	protected class SelectedNodes implements NodeList {
-
-		/**
-		 * The selected nodes.
-		 */
-		protected ArrayList<Node> nodes = new ArrayList<>(10);
+	protected class SelectedNodes extends ArrayNodeList {
 
 		/**
 		 * Creates a new SelectedNodes object.
@@ -113,23 +109,6 @@ public class DefaultContentSelector extends AbstractContentSelector {
 			return false;
 		}
 
-		/**
-		 * <b>DOM</b>: Implements {@link org.w3c.dom.NodeList#item(int)}.
-		 */
-		@Override
-		public Node item(int index) {
-			if (index < 0 || index >= nodes.size()) {
-				return null;
-			}
-			return nodes.get(index);
-		}
-
-		/**
-		 * <b>DOM</b>: Implements {@link org.w3c.dom.NodeList#getLength()}.
-		 */
-		@Override
-		public int getLength() {
-			return nodes.size();
-		}
 	}
+
 }

--- a/echosvg-bridge/src/main/java/io/sf/carte/echosvg/bridge/svg12/XPathPatternContentSelector.java
+++ b/echosvg-bridge/src/main/java/io/sf/carte/echosvg/bridge/svg12/XPathPatternContentSelector.java
@@ -35,6 +35,7 @@ import org.w3c.dom.xpath.XPathException;
 
 import io.sf.carte.echosvg.anim.dom.XBLOMContentElement;
 import io.sf.carte.echosvg.dom.AbstractDocument;
+import io.sf.carte.echosvg.dom.ArrayNodeList;
 
 /**
  * A class to handle the XPath Pattern syntax for XBL content elements.
@@ -120,12 +121,7 @@ public class XPathPatternContentSelector extends AbstractContentSelector {
 	 * Implementation of NodeList that contains the nodes that matched this
 	 * selector.
 	 */
-	protected class SelectedNodes implements NodeList {
-
-		/**
-		 * The selected nodes.
-		 */
-		protected ArrayList<Node> nodes = new ArrayList<>(10);
+	protected class SelectedNodes extends ArrayNodeList {
 
 		/**
 		 * Creates a new SelectedNodes object.
@@ -184,26 +180,9 @@ public class XPathPatternContentSelector extends AbstractContentSelector {
 							"xpath.error", new Object[] { expression, te.getMessage() });
 				}
 			}
+
 		}
 
-		/**
-		 * <b>DOM</b>: Implements {@link org.w3c.dom.NodeList#item(int)}.
-		 */
-		@Override
-		public Node item(int index) {
-			if (index < 0 || index >= nodes.size()) {
-				return null;
-			}
-			return nodes.get(index);
-		}
-
-		/**
-		 * <b>DOM</b>: Implements {@link org.w3c.dom.NodeList#getLength()}.
-		 */
-		@Override
-		public int getLength() {
-			return nodes.size();
-		}
 	}
 
 	/**

--- a/echosvg-bridge/src/main/java/io/sf/carte/echosvg/bridge/svg12/XPathSubsetContentSelector.java
+++ b/echosvg-bridge/src/main/java/io/sf/carte/echosvg/bridge/svg12/XPathSubsetContentSelector.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import io.sf.carte.echosvg.anim.dom.XBLOMContentElement;
+import io.sf.carte.echosvg.dom.ArrayNodeList;
 import io.sf.carte.echosvg.parser.AbstractScanner;
 import io.sf.carte.echosvg.parser.ParseException;
 import io.sf.carte.echosvg.xml.XMLUtilities;
@@ -208,12 +209,7 @@ public class XPathSubsetContentSelector extends AbstractContentSelector {
 	 * Implementation of NodeList that contains the nodes that matched this
 	 * selector.
 	 */
-	protected class SelectedNodes implements NodeList {
-
-		/**
-		 * The selected nodes.
-		 */
-		protected ArrayList<Node> nodes = new ArrayList<>(10);
+	protected class SelectedNodes extends ArrayNodeList {
 
 		/**
 		 * Creates a new SelectedNodes object.
@@ -269,24 +265,6 @@ public class XPathSubsetContentSelector extends AbstractContentSelector {
 			return false;
 		}
 
-		/**
-		 * <b>DOM</b>: Implements {@link org.w3c.dom.NodeList#item(int)}.
-		 */
-		@Override
-		public Node item(int index) {
-			if (index < 0 || index >= nodes.size()) {
-				return null;
-			}
-			return nodes.get(index);
-		}
-
-		/**
-		 * <b>DOM</b>: Implements {@link org.w3c.dom.NodeList#getLength()}.
-		 */
-		@Override
-		public int getLength() {
-			return nodes.size();
-		}
 	}
 
 	/**

--- a/echosvg-css/src/main/java/io/sf/carte/echosvg/css/engine/SVGSelectorMatcher.java
+++ b/echosvg-css/src/main/java/io/sf/carte/echosvg/css/engine/SVGSelectorMatcher.java
@@ -15,19 +15,29 @@
  */
 package io.sf.carte.echosvg.css.engine;
 
+import org.w3c.dom.Element;
+
 import io.sf.carte.doc.style.css.SelectorMatcher;
 import io.sf.carte.doc.style.css.om.BaseSelectorMatcher;
 
-class SVGSelectorMatcher extends BaseSelectorMatcher<CSSStylableElement> {
+/**
+ * Used for CSS selector matching.
+ */
+public class SVGSelectorMatcher extends BaseSelectorMatcher<Element> {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
-	SVGSelectorMatcher(CSSStylableElement elt) {
+	/**
+	 * Construct a new matcher.
+	 * 
+	 * @param elt the element to check for matches.
+	 */
+	public SVGSelectorMatcher(Element elt) {
 		super(elt);
 	}
 
 	@Override
-	protected SelectorMatcher obtainSelectorMatcher(CSSStylableElement element) {
+	protected SelectorMatcher obtainSelectorMatcher(Element element) {
 		return new SVGSelectorMatcher(element);
 	}
 

--- a/echosvg-dom/src/main/java/io/sf/carte/echosvg/dom/AbstractElement.java
+++ b/echosvg-dom/src/main/java/io/sf/carte/echosvg/dom/AbstractElement.java
@@ -28,7 +28,11 @@ import org.w3c.dom.Node;
 import org.w3c.dom.TypeInfo;
 import org.w3c.dom.events.MutationEvent;
 
+import io.sf.carte.doc.style.css.SelectorMatcher;
+import io.sf.carte.doc.style.css.nsac.Condition;
+import io.sf.carte.doc.style.css.nsac.SelectorList;
 import io.sf.carte.echosvg.constants.XMLConstants;
+import io.sf.carte.echosvg.css.engine.SVGSelectorMatcher;
 import io.sf.carte.echosvg.dom.events.DOMMutationEvent;
 import io.sf.carte.echosvg.dom.util.DOMUtilities;
 import io.sf.carte.echosvg.w3c.dom.ElementTraversal;
@@ -747,6 +751,30 @@ public abstract class AbstractElement extends AbstractParentChildNode implements
 	public int getChildElementCount() {
 		getChildNodes();
 		return childNodes.elementChildren;
+	}
+
+	/**
+	 * Match the given selectors.
+	 * 
+	 * @param selectors the selector list.
+	 * @return true if this element matches the selectors.
+	 */
+	public boolean matches(String selectors) {
+		SelectorList selist = parseSelectors(selectors);
+		return matches(selist, null);
+	}
+
+	/**
+	 * Match the given selectors.
+	 * 
+	 * @param selist        the selector list.
+	 * @param pseudoElement the pseudo-element, or {@code null} if none.
+	 * @return true if this element matches the selector list.
+	 */
+	boolean matches(SelectorList selist, Condition pseudoElement) {
+		SelectorMatcher matcher = new SVGSelectorMatcher(this);
+		matcher.setPseudoElement(pseudoElement);
+		return matcher.matches(selist) != -1;
 	}
 
 	/**

--- a/echosvg-dom/src/main/java/io/sf/carte/echosvg/dom/ArrayNodeList.java
+++ b/echosvg-dom/src/main/java/io/sf/carte/echosvg/dom/ArrayNodeList.java
@@ -1,0 +1,79 @@
+/*
+
+   See the NOTICE file distributed with this work for additional
+   information regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ */
+package io.sf.carte.echosvg.dom;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * An {@link ArrayList}-backed node list.
+ */
+public class ArrayNodeList implements NodeList, Iterable<Node> {
+
+	/**
+	 * The nodes.
+	 */
+	protected final ArrayList<Node> nodes;
+
+	/**
+	 * Construct a node list of the default size (10).
+	 */
+	public ArrayNodeList() {
+		super();
+		nodes = new ArrayList<>(10);
+	}
+
+	/**
+	 * Construct a node list of the given size.
+	 * 
+	 * @param size the size.
+	 */
+	public ArrayNodeList(int size) {
+		super();
+		nodes = new ArrayList<>(size);
+	}
+
+	@Override
+	public Node item(int index) {
+		if (index < 0 || index >= nodes.size()) {
+			return null;
+		}
+		return nodes.get(index);
+	}
+
+	@Override
+	public int getLength() {
+		return nodes.size();
+	}
+
+	/**
+	 * Returns an iterator over the nodes of this list.
+	 * 
+	 * @return an iterator.
+	 */
+	@Override
+	public Iterator<Node> iterator() {
+		return Collections.unmodifiableList(nodes).iterator();
+	}
+
+}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/QuerySelectorTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/QuerySelectorTest.java
@@ -1,0 +1,133 @@
+/*
+
+   See the NOTICE file distributed with this work for additional
+   information regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ */
+package io.sf.carte.echosvg.dom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import io.sf.carte.echosvg.dom.util.DocumentFactory;
+import io.sf.carte.echosvg.dom.util.SAXDocumentFactory;
+
+/**
+ * Test the matches, querySelector and querySelectorAll methods.
+ *
+ * @version $Id$
+ */
+public class QuerySelectorTest {
+
+	@Test
+	public void testTypeSelectors() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "elt2", "elt2", "elt2",
+				1);
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "elt4", "elt4", "", 1);
+	}
+
+	@Test
+	public void testAttributeSelectors() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "[attr='value1']", "doc",
+				"root", 1);
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "[attr2='value2']",
+				"elt2", "elt2", 1);
+	}
+
+	@Test
+	public void testIdSelectors() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "elt2#elt2", "elt2",
+				"elt2", 1);
+	}
+
+	@Test
+	public void testPseudoClassEmpty() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", ":empty", "elt1", "", 2);
+	}
+
+	@Test
+	public void testPseudoClassRoot() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", ":root", "doc", "root",
+				1);
+	}
+
+	@Test
+	public void testPseudoClassLastChild() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", ":last-child", "doc",
+				"root", 3);
+	}
+
+	@Test
+	public void testPseudoClassFirstLastChild() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc",
+				":first-child,:last-child", "doc", "root", 4);
+	}
+
+	@Test
+	public void testPseudoClassNthChild() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", ":nth-child(3)", "elt3",
+				"", 1);
+	}
+
+	@Test
+	public void testDescendant() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "doc elt4", "elt4", "",
+				1);
+	}
+
+	@Test
+	public void testChild() throws IOException {
+		testQuerySelector("io/sf/carte/echosvg/dom/dummyXML4.xml", "doc", "elt3>elt4", "elt4", "",
+				1);
+	}
+
+	void testQuerySelector(String testFileName, String rootTag, String selector, String tagName,
+			String nodeID, int listCount) throws IOException {
+		DocumentFactory df = new SAXDocumentFactory(
+				GenericDOMImplementation.getDOMImplementation());
+
+		// Load the document
+		URL url = getClass().getClassLoader().getResource(testFileName);
+		Document doc = df.createDocument(null, rootTag, url.toString(), url.openStream());
+
+		AbstractParentNode docNode = (AbstractParentNode) doc;
+
+		// querySelector
+		Element elt = docNode.querySelector(selector);
+
+		assertNotNull(elt);
+		assertEquals(tagName, elt.getTagName());
+		assertEquals(nodeID, elt.getAttribute("id"));
+		assertTrue(((AbstractElement) elt).matches(selector));
+
+		// querySelectorAll
+		NodeList list = docNode.querySelectorAll(selector);
+
+		assertNotNull(list);
+		assertEquals(listCount, list.getLength());
+		assertSame(elt, list.item(0));
+	}
+
+}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/QuerySelectorSVGDOMTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/dom/svg/QuerySelectorSVGDOMTest.java
@@ -1,0 +1,87 @@
+/*
+
+   See the NOTICE file distributed with this work for additional
+   information regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ */
+package io.sf.carte.echosvg.dom.svg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import io.sf.carte.echosvg.anim.dom.SAXSVGDocumentFactory;
+import io.sf.carte.echosvg.dom.AbstractElement;
+import io.sf.carte.echosvg.dom.AbstractParentNode;
+import io.sf.carte.echosvg.dom.ArrayNodeList;
+
+/**
+ * This class tests the querySelector method in the SVG DOM implementation.
+ *
+ * @version $Id$
+ */
+public class QuerySelectorSVGDOMTest {
+
+	@Test
+	public void test() throws IOException {
+		runTest("io/sf/carte/echosvg/dom/svg/test.svg", "#nodeID");
+		runTest("io/sf/carte/echosvg/dom/svg/test.svg", "svg");
+	}
+
+	void runTest(String testFileName, String selector) throws IOException {
+		SAXSVGDocumentFactory df = new SAXSVGDocumentFactory();
+
+		// Load the document
+		URL url = getClass().getClassLoader().getResource(testFileName);
+		Document doc = df.createDocument(url.toString(), url.openStream(), "utf-8");
+
+		AbstractParentNode docNode = (AbstractParentNode) doc;
+
+		// querySelector
+		Element elt = docNode.querySelector(selector);
+
+		assertNotNull(elt);
+		assertEquals("svg", elt.getLocalName());
+		assertEquals("nodeID", elt.getAttribute("id"));
+
+		// querySelectorAll
+		NodeList list = docNode.querySelectorAll(selector);
+
+		assertNotNull(list);
+		assertEquals(1, list.getLength());
+		assertSame(elt, list.item(0));
+
+		// Test the iterator
+		Iterator<Node> it = ((ArrayNodeList) list).iterator();
+		Node n = it.next();
+		assertTrue(((AbstractElement) n).matches(selector));
+		assertFalse(it.hasNext());
+		assertThrows(UnsupportedOperationException.class, () -> it.remove());
+	}
+
+}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/HTMLRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/HTMLRenderingAccuracyTest.java
@@ -39,7 +39,11 @@ class HTMLRenderingAccuracyTest extends XHTMLRenderingAccuracyTest {
 	private final HtmlParser parser;
 
 	public HTMLRenderingAccuracyTest() {
-		super();
+		this(null);
+	}
+
+	public HTMLRenderingAccuracyTest(String selector) {
+		super(selector);
 		setValidating(false);
 		parser = new HtmlParser(XmlViolationPolicy.ALTER_INFOSET);
 		parser.setCommentPolicy(XmlViolationPolicy.ALLOW);

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SamplesRenderingTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/SamplesRenderingTest.java
@@ -952,6 +952,11 @@ public class SamplesRenderingTest {
 	}
 
 	@Test
+	public void testHTMLEmbedSelector() throws TranscoderException, IOException {
+		testHTML("samples/tests/spec/styling/css2.html", "#theSVG");
+	}
+
+	@Test
 	public void testXHTMLEmbed() throws TranscoderException, IOException {
 		testXHTML("samples/tests/spec/styling/css2.xhtml");
 	}
@@ -1643,7 +1648,24 @@ public class SamplesRenderingTest {
 	 * @throws IOException
 	 */
 	private void testHTML(String file) throws TranscoderException, IOException {
-		RenderingTest runner = new HTMLRenderingAccuracyTest();
+		testHTML(file, null);
+	}
+
+	/**
+	 * Test the rendering of a SVG image inside an HTML document.
+	 * 
+	 * <p>
+	 * A small percentage of different pixels is allowed during the comparison to a
+	 * reference image.
+	 * </p>
+	 * 
+	 * @param file the HTML file to test.
+	 * @param the selector that locates the desired SVG element.
+	 * @throws TranscoderException
+	 * @throws IOException
+	 */
+	private void testHTML(String file, String selector) throws TranscoderException, IOException {
+		RenderingTest runner = new HTMLRenderingAccuracyTest(selector);
 		runner.setFile(file);
 		runner.runTest(0.000001f, 0.000001f);
 	}

--- a/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/XHTMLRenderingAccuracyTest.java
+++ b/echosvg-test/src/test/java/io/sf/carte/echosvg/test/svg/XHTMLRenderingAccuracyTest.java
@@ -18,6 +18,7 @@
  */
 package io.sf.carte.echosvg.test.svg;
 
+import io.sf.carte.echosvg.transcoder.SVGAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.XMLAbstractTranscoder;
 import io.sf.carte.echosvg.transcoder.image.ImageTranscoder;
 
@@ -29,8 +30,15 @@ import io.sf.carte.echosvg.transcoder.image.ImageTranscoder;
  */
 public class XHTMLRenderingAccuracyTest extends RenderingTest {
 
+	private final String selector;
+
 	public XHTMLRenderingAccuracyTest() {
+		this(null);
+	}
+
+	public XHTMLRenderingAccuracyTest(String selector) {
 		super();
+		this.selector = selector;
 		setValidating(false);
 	}
 
@@ -43,6 +51,9 @@ public class XHTMLRenderingAccuracyTest extends RenderingTest {
 		t.addTranscodingHint(XMLAbstractTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,
 				"http://www.w3.org/1999/xhtml");
 		t.addTranscodingHint(XMLAbstractTranscoder.KEY_DOCUMENT_ELEMENT, "html");
+		if (selector != null) {
+			t.addTranscodingHint(SVGAbstractTranscoder.KEY_SVG_SELECTOR, selector);
+		}
 		return t;
 	}
 

--- a/echosvg-transcoder/src/main/java/io/sf/carte/echosvg/transcoder/util/CSSTranscodingHelper.java
+++ b/echosvg-transcoder/src/main/java/io/sf/carte/echosvg/transcoder/util/CSSTranscodingHelper.java
@@ -615,6 +615,10 @@ public class CSSTranscodingHelper {
 
 		// Determine the SVG root element
 		DOMElement svgRoot = null;
+		if (selector == null) {
+			selector = (String) transcoder.getTranscodingHints()
+					.get(SVGAbstractTranscoder.KEY_SVG_SELECTOR);
+		}
 		if (selector != null && (selector = selector.trim()).length() != 0) {
 			svgRoot = document.querySelectorAll(selector).item(0);
 		}

--- a/samples/tests/spec/styling/css2.html
+++ b/samples/tests/spec/styling/css2.html
@@ -34,7 +34,7 @@ text.itemdesc {
 </head>
 <body>
 <!-- svg elements without a namespace declaration are legal in plain HTML -->
-<svg width="500" height="500">
+<svg width="500" height="500" id="theSVG">
   <style>
 /*<![CDATA[*/
 


### PR DESCRIPTION
## Implement `matches()`, `querySelector()` and `querySelectorAll()`

 - https://dom.spec.whatwg.org/#dom-element-matches
 - https://dom.spec.whatwg.org/#dom-parentnode-queryselector
 - https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall

## Add the `KEY_SVG_SELECTOR` transcoding hint

If `KEY_SVG_SELECTOR` is set and the document is HTML, its value as a CSS selector is used to locate the element that will be used as the SVG root.

In the case of the transcoding helper, if the selector argument is null then `KEY_SVG_SELECTOR` is used, and if also null then the previous behaviour follows.

If you come up with a better name for `KEY_SVG_SELECTOR`, please comment here.

This new hint is part of the effort to make EchoSVG friendly to embedded SVG images, see #40.